### PR TITLE
Add graft connections ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,48 @@ Add a single GitHub repo to an ADO connection. For the `REPO` argument, you must
 
 In a file specify the repos to be added to the connection, one per line. You can find the connection ID by running `gh artado list`.The repo names will the be the full URL. Be sure that the repos are on newlines and not comma separated.
 
-## WIP: Update a connection's repos to match a file: 
+## Snapshot the state of connections and their repos to a YAML file:
 
-There are two options to connect ADO boards to GitHub Enterprise Cloud: either through a GitHub OAuth connection or a GitHub Personal Access Token (PAT). With either option, it's possible for the connection to expire. This is especially common for PAT-based ADO<->GitHub connections when the GitHub PAT expires. Currently there's no method in the ADO UI or a direct method in the API to refresh the PAT _or_ re-create the connection automatically.
+`gh artado output`
 
-This CLI method provides a workaround for these use cases: 
+This command will output a YAML file that contains the state of all connections and their repos. This is useful for creating a snapshot of the state of your connections and repos at a certain time. You can use this file as an argument to `gh artado graft` to rebuild a connection and its repos. Here's an example of the output: 
 
-`gh artado graft connections-2023-10-23-16.yaml --from 4b53-a947-fcffb033f7ec --to ce189438-3344`
+```yaml
+- id: 3aa9d254-413ac
+  url: ""
+  repository: ""
+  accesstoken: ""
+  authorizationheader: ""
+  githubrepositoryurl: |-
+    https://github.com/ursa-minus/ab
+    https://github.com/ursa-minus/za
+    https://github.com/ursa-minus/foobar
+  name: apdarr
+- id: 6f6969a7-26b0
+  repository: ""
+  accesstoken: ""
+  authorizationheader: ""
+  githubrepositoryurl: |-
+    https://github.com/ursa-minus/try-foo
+    https://github.com/ursa-minus/try-bar
+  name: apdarr
+  name: apdarr_fabrikam
+```
 
-What this command does: 
+By using the `cron_workflow.yml` file in this repo, you can run this command on a regular basis in a GitHub Actions workflow, which will thereby create a record of connections and repos at a certain time. Checkout the below section for why this is important. 
+
+## Update a connection's repos to match a past snapshot: 
+
+When managing the connection between ADO boards and GitHub repos, it's possible for the connection to expire. This is especially common for PAT-based ADO<->GitHub connections when the GitHub PAT expires. Currently there's no method in the ADO UI or a direct method in the API to refresh the PAT _or_ re-create the connection automatically. The alternative is to manually re-create the connection in the ADO UI, using the UI to click through the steps to re-create the connection. 
+
+This CLI method provides a workaround for these use cases. By referencing a past snapshot (thanks to the `gh artado output` command) of the connection and its repos, we can re-create the connection and its repos.: 
+
+`gh artado graft connections-2023-10-23-16.yml --from 3aa9d254-413ac --to ce189438-3344`
+
+Let's dig into what this command is doing: 
 - We read in a YAML file that contains a list of connections and their repos for a certain date. Running `gh artado ouput` will generate a timestamped YAML file that captures the state of all connections and their repos at that time. You can run this command on a regular basis, for example on a cron job or in a GitHub Action workflow, to create snapshots of your ADO connections.
-- This .yaml file is then parsed as an argument to `gh artado graft`. The CLI will use the connection state described in that .yaml file to rebuild a newly created repo (described below). 
-- The `--from` argument is the connection ID of the connection in the .yaml file that you want to use as the source of truth for the new connection. The intention is to reference a historical connection ID (represented in our .yaml file) and transfer its repos to to a new connection. 
+  - At the root of this repo, you'll finde a `cron_workflow.yml` file that you can use to run `artado` on a regular basis. The workflow will run `gh artado output` and then commit the resulting YAML file to the repo from which the workflow runs.
+- This .yml file is then parsed as an argument to `gh artado graft`. The CLI will use the connection state described in that .yml file to rebuild a newly created repo (described below). 
+- The `--from` argument references a chosen connection ID in the .yml file. As seen above, each connection ID lists under a connection ID key. So this argument instructs the CLI to build _from_ this snapshot state _to_ a new, active connection. 
 - The `--to` argument represents the new connection ID. The repos listed under the `4b53-a947-fcffb033f7ec` for example will be added to the newly built `ce189438-3344` connection.  
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ Add a single GitHub repo to an ADO connection. For the `REPO` argument, you must
  `gh artado add-bulk -f repos.txt -c 3aa9d254-413a-4b53-a947-fcffb033f7ec`
 
 In a file specify the repos to be added to the connection, one per line. You can find the connection ID by running `gh artado list`.The repo names will the be the full URL. Be sure that the repos are on newlines and not comma separated.
+
+## WIP: Update a connection's repos to match a file: 
+
+There are two options to connect ADO boards to GitHub Enterprise Cloud: either through a GitHub OAuth connection or a GitHub Personal Access Token (PAT). With either option, it's possible for the connection to expire. This is especially common for PAT-based ADO<->GitHub connections when the GitHub PAT expires. Currently there's no method in the ADO UI or a direct method in the API to refresh the PAT _or_ re-create the connection automatically.
+
+This CLI method provides a workaround for these use cases: 
+
+`gh artado graft connections-2023-10-23-16.yaml --from 4b53-a947-fcffb033f7ec --to ce189438-3344`
+
+What this command does: 
+- We read in a YAML file that contains a list of connections and their repos for a certain date. Running `gh artado ouput` will generate a timestamped YAML file that captures the state of all connections and their repos at that time. You can run this command on a regular basis, for example on a cron job or in a GitHub Action workflow, to create snapshots of your ADO connections.
+- This .yaml file is then parsed as an argument to `gh artado graft`. The CLI will use the connection state described in that .yaml file to rebuild a newly created repo (described below). 
+- The `--from` argument is the connection ID of the connection in the .yaml file that you want to use as the source of truth for the new connection. The intention is to reference a historical connection ID (represented in our .yaml file) and transfer its repos to to a new connection. 
+- The `--to` argument represents the new connection ID. The repos listed under the `4b53-a947-fcffb033f7ec` for example will be added to the newly built `ce189438-3344` connection.  
+

--- a/cron_workflow.yml
+++ b/cron_workflow.yml
@@ -1,0 +1,27 @@
+name: Run gh artado output
+
+on:
+  schedule:
+    - cron:  '0 0 * * *' # Runs every 24 hours
+
+jobs:
+  run-command:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install gh-artado extension
+      run: gh extension install apdarr/gh-artado
+
+    - name: Run command
+      run: gh artado output
+
+    - name: Commit and push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Add generated .yaml file" 
+        git push

--- a/main.go
+++ b/main.go
@@ -533,8 +533,6 @@ func graftConnection(connFile string) error {
 		log.Fatalf("error: %v", err)
 	}
 
-	fmt.Printf("The following repos will be added to connection %s:\n", connectedRepos)
-
 	// Create a string of the repo URLs.
 	// Grab the repo URLs from the connSource connection ID key and add them to the connTarget connection ID key
 	var repoSlice []string

--- a/main.go
+++ b/main.go
@@ -397,6 +397,8 @@ func runAddRepo(repoUrl string, connectionID string) (map[string]string, error) 
 		m := make(map[string]string)
 		m[connectionID] = repoUrl
 
+		fmt.Printf("Successfully added repo %s to connection %s\n", repoUrl, connectionID)
+
 		return m, nil
 
 	} else {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ type Connection struct {
 	Name                string `json:"name"`
 }
 
+type ConnectionFile struct {
+	ID                  string `yaml:"id"`
+	GitHubRepositoryUrl string `yaml:"githubrepositoryurl"`
+	Name                string `yaml:"name"`
+}
+
 type Response struct {
 	Value []struct {
 		ID                string `json:"id"`
@@ -445,8 +451,18 @@ func outputConnectionFile() (string, error) {
 		log.Fatal(err)
 	}
 
+	// Filter the connections
+	var filteredConnections []ConnectionFile
+	for _, c := range connections {
+		filteredConnections = append(filteredConnections, ConnectionFile{
+			ID:                  c.ID,
+			GitHubRepositoryUrl: c.GitHubRepositoryUrl,
+			Name:                c.Name,
+		})
+	}
+
 	// Marshal the connections to YAML
-	data, err := yaml.Marshal(&connections)
+	data, err := yaml.Marshal(&filteredConnections)
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -466,3 +482,22 @@ func outputConnectionFile() (string, error) {
 
 	return string(data), nil
 }
+
+// // Consume a .yml file and add the repos to a new connection in ADO using the connection name as the key
+// func graftConnection(connFile string, connSource string, connTarget string) {
+// 	// read in the .yml file from connFile (path to file). Error if you the file is empty or malformed
+// 	// Unmarshal the YAML to a struct, grab all the repos using connSource as a key
+// 	// If the key cannot be found, return an error
+// 	// At the connSource key, fetch all repos in that file. Ensure that connTarget is active and then add them to connTarget.
+
+// 	// Read in the YAML file
+// 	yamlFile, err := os.ReadFile(connFile)
+
+// 	if err != nil {
+// 		log.Fatalf("error: %v", err)
+// 	}
+
+// 	// Unmarshal the YAML to a struct
+// 	var connections []Connection
+// 	err = yaml.Unmarshal(yamlFile, &connections)
+// }

--- a/main.go
+++ b/main.go
@@ -399,15 +399,6 @@ func runAddRepo(repoUrl string, connectionID string) (map[string]string, error) 
 
 		return m, nil
 
-		// fmt.Printf("Added repo %s to connection %s\n", repoUrl, connectionID)
-
-		// // create a new table showing successfully adding repo to connection
-		// tb1 := table.NewWriter()
-		// tb1.SetOutputMirror(os.Stdout)
-		// tb1.AppendHeader(table.Row{"Connection ID", "Repo Name (added)"})
-		// tb1.AppendRow([]interface{}{connectionID, repoUrl})
-		// tb1.SetStyle(table.StyleColoredDark)
-		// tb1.Render()
 	} else {
 		fmt.Println("Error adding repo to connection")
 		err := fmt.Errorf("failed to add repo %s to connection %s", repoUrl, connectionID)
@@ -456,9 +447,6 @@ func runAddBulkRepos(txtFile string, connectionID string) ([]map[string]string, 
 	}
 
 	fmt.Printf("Adding %d repositories to connection %s\n", len(repos), connectionID)
-
-	// Add each repo to the connection
-	//var addedRepos []string
 
 	// Create a slice of maps of successfully added repos
 	var addedRepos []map[string]string
@@ -539,6 +527,8 @@ func graftConnection(fileName string) ([]string, error) {
 
 	connSource := "3aa9d254-413a-4b53-a947-fcffb033f7ec"
 
+	connTarget := "3aa9d254-413a-4b53-a947-fcffb033f7ec"
+
 	var urls []string
 	for _, c := range connFile {
 		if c.ID == connSource {
@@ -547,5 +537,11 @@ func graftConnection(fileName string) ([]string, error) {
 		}
 	}
 
+	for _, url := range urls {
+		_, err := runAddRepo(url, connTarget)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return urls, nil
 }

--- a/main.go
+++ b/main.go
@@ -499,7 +499,7 @@ func outputConnectionFile() (string, error) {
 		log.Fatal(err)
 	}
 
-	filename := fmt.Sprintf("connections/connections-%s.yaml", time.Now().Format("2006-01-02-15-04-05"))
+	filename := fmt.Sprintf("connections/connections-%s.yml", time.Now().Format("2006-01-02-15-04-05"))
 
 	// Write the YAML to a file.
 	err = os.WriteFile(filename, data, 0644)


### PR DESCRIPTION
Add another subcommand that: 

- References a list of repos from an previous connection state, captured as .yaml file (courtesy of the `outputConnectionFile` function.
- Adds those repos, previously added to a now expired connection, to an active connection. 
- The subcommand takes three arguments: 
  - The file directory where the .yaml file exists
  - The source connection ID (referring to an expired connection) that contains the repos you'd like to add
  - The target, active connection ID to which you'd like to add these connections

The purpose of this subcommand is to work around cases where connections expire in ADO-GitHub integrations. By keeping a record of connections states via this CLI's `output` command, we can simply `graft` a previous state-of-connections and its repos to an active connection ID. The latter is what this PR accomplishes.    