### PR TITLE
Add graft subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This extension requires the [GitHub CLI](https://cli.github.com/) to be installe
 
 # Required env vars
 
-`ADO_USER` = your ADO username
-`ADO_PAT` = your ADO personal access token
+- `ADO_USER` = your ADO username
+- `ADO_PAT` = your ADO personal access token
+- `ADO_PROJECT` = the ADO project name in which your boards are located. For example, `fabrikam/fabric`
 
 Must also configure ADO: 
 - Install the GitHub ADO app to your GitHub (or even to a single repo)

--- a/connections-2024-01-09-15-15-44.yml
+++ b/connections-2024-01-09-15-15-44.yml
@@ -1,0 +1,20 @@
+- id: 3aa9d254-413a-4b53-a947-fcffb033f7ec
+  githubRepositoryUrl:
+  - ""
+  name: apdarr
+  authorizationType: PersonalAccessToken
+- id: 0b917947-09a2-4aa7-8d72-0576890f3852
+  githubRepositoryUrl:
+  - https://github.com/ursa-minus/art-4
+  - https://github.com/ursa-minus/art-3
+  name: MDEyOk9yZ2FuaXphdGlvbjg1MTI5NzYz-44577736
+  authorizationType: InstallationToken
+- id: 913cab20-88bf-43da-a9fb-7f7711bf4ee0
+  githubRepositoryUrl:
+  - https://github.com/ursa-minus/actions-ci-cd
+  - https://github.com/ursa-minus/art-0
+  - https://github.com/ursa-minus/art-1
+  - https://github.com/ursa-minus/spectral-test
+  - https://github.com/ursa-minus/p-t
+  name: MDEyOk9yZ2FuaXphdGlvbjkxNDg2ODY3-44611209
+  authorizationType: InstallationToken

--- a/main.go
+++ b/main.go
@@ -21,12 +21,13 @@ import (
 
 type Connection struct {
 	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	GitHubRepositoryUrl string `json:"gitHubRepositoryUrl"`
+	AuthorizationType   string `json:"authorizationType"`
+	IsConnectionValid   bool   `json:"isConnectionValid"`
 	Url                 string `json:"url"`
 	Repository          string `json:"repository"`
-	AccessToken         string `json:"accessToken"`
 	AuthorizationHeader string `json:"authorizationHeader"`
-	GitHubRepositoryUrl string `json:"gitHubRepositoryUrl"`
-	Name                string `json:"name"`
 }
 
 type ConnectionFile struct {
@@ -136,10 +137,10 @@ func _main() error {
 			// Print the table
 			tb1 := table.NewWriter()
 			tb1.SetOutputMirror(os.Stdout)
-			tb1.AppendHeader(table.Row{"Connection ID", "Connection Name", "Repo Name"})
+			tb1.AppendHeader(table.Row{"Connection ID", "Connection Name", "Connection Type", "Connected Repo(s)"})
 
 			for _, connection := range connections {
-				tb1.AppendRow([]interface{}{connection.ID, connection.Name, connection.GitHubRepositoryUrl})
+				tb1.AppendRow([]interface{}{connection.ID, connection.Name, connection.AuthorizationType, connection.GitHubRepositoryUrl})
 			}
 			tb1.SetStyle(table.StyleColoredDark)
 			tb1.Render()
@@ -314,14 +315,10 @@ func main() {
 }
 
 func runListConnections() ([]Connection, error) {
-
 	adoProject := getAdoProject()
 	endpoint := fmt.Sprintf("https://dev.azure.com/%s/_apis/githubconnections?api-version=7.1-preview", adoProject)
-	fmt.Printf("Endpoint: %s\n", endpoint)
 
 	adoResponse := returnURlBody("GET", endpoint)
-
-	fmt.Print(adoResponse)
 
 	var jsonResponse struct {
 		Count int          `json:"count"`
@@ -344,6 +341,7 @@ func runListConnections() ([]Connection, error) {
 			return nil, fmt.Errorf("error parsing JSON: %w", err)
 		}
 
+		// Assign the connection name field to the connection struct
 		jsonResponse.Value[i].Name = connection.Name
 
 		// Get the list of respitories connected to the connection

--- a/main.go
+++ b/main.go
@@ -565,34 +565,14 @@ func graftConnection(cFile string, fromFlag string, toFlag string) ([]string, er
 		return nil, err
 	}
 
-	// Prints debugging
-	// ******************************************************
-	// fmt.Printf("Grafting repos from connection %s to connection %s\n", fromFlag, toFlag)
-	// fmt.Printf("Found %d connections in file\n", len(connFile))
-	// // Print the connections in the file
-	// for _, c := range connFile {
-	// 	fmt.Printf("Connection ID: %s\n", c.ID)
-	// 	fmt.Printf("Connection Name: %s\n", c.Name)
-	// }
-	// ******************************************************
-
+	// Create an empty slice to hold the repo URLs if we find a match
 	var urls []string
-
-	// Loop through the connections to collect a slice a repo URLs for grafting
-	// for _, c := range connFile {
-	// 	if c.ID == fromFlag {
-	// 		urls = strings.Split(c.GitHubRepositoryUrl, "\n")
-	// 		break
-	// 	}
-	// }
+	// Create a bool to track if we found a match
 	found := false
+	// Loop through the connections file and collect the matching conn ID's repos in a slice
 	for _, c := range connFile {
-		//fmt.Printf("⭐️ looking for a match between %s and %s\n", c.ID, fromFlag)
 		if c.ID == fromFlag {
-			// fmt.Printf("Found connection ID %s\n", fromFlag)
-			// fmt.Printf("Repo URLs: %s\n", c.GitHubRepositoryUrl)
 			urls = c.GitHubRepositoryUrl
-			// exit the loop if we found the matching connection ID
 			found = true
 			break
 		}
@@ -609,42 +589,47 @@ func graftConnection(cFile string, fromFlag string, toFlag string) ([]string, er
 			return nil, err
 		}
 	}
+
+	// New functionality to verify that the repos were added to the connection
+
 	// Get a list of connections to verify that they've been added from the graft operation
-	connections, err := runListConnections()
-	if err != nil {
-		return nil, err
-	}
+	// connections, err := runListConnections()
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	// Find the connection with the toFlag ID
-	var toConnection *Connection
-	for _, conn := range connections {
-		if conn.ID == toFlag {
-			toConnection = &conn
-			break
-		}
-	}
+	// // Initialize a pointer to a connection struct
+	// var toConnection *Connection
+	// // Iterate over the connections structs slice and find the one with the toFlag ID
+	// for _, conn := range connections {
+	// 	if conn.ID == toFlag {
+	// 		toConnection = &conn
+	// 		break
+	// 	}
+	// }
 
-	// If the toFlag connection wasn't found, return an error
-	if toConnection == nil {
-		return nil, fmt.Errorf("connection ID %s not found", toFlag)
-	}
+	// // If the toFlag connection wasn't found, return an error
+	// if toConnection == nil {
+	// 	return nil, fmt.Errorf("connection ID %s not found", toFlag)
+	// }
 
-	// Check if all the repos in the URL slice are present in the toFlag connection
-	for _, url := range urls {
-		if !contains(toConnection.GitHubRepositoryUrl, url) {
-			return nil, fmt.Errorf("repo %s not found in connection %s", url, toFlag)
-		}
-	}
+	// // Split the connection's repo URLs into a slice
+	// toConnectionUrls := strings.Split(toConnection.GitHubRepositoryUrl, "\n")
+
+	// // Next, iterate through urls current present on the connection (toConnectionUrls)
+	// for _, url := range toConnectionUrls {
+	// 	found := false
+	// 	// For each repo URL, check to see if it's in the urls slice - in other words, check to see if it was added
+	// 	for _, repo := range urls {
+	// 		if repo == url {
+	// 			found = true
+	// 			break
+	// 		}
+	// 	}
+	// 	if !found {
+	// 		return nil, fmt.Errorf("repo %s not found in connection %s", url, toFlag)
+	// 	}
+	// }
 
 	return urls, nil
-}
-
-func contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-
-	return false
 }

--- a/main.go
+++ b/main.go
@@ -32,14 +32,15 @@ type Connection struct {
 
 type ConnectionFile struct {
 	ID                  string   `yaml:"id"`
-	GitHubRepositoryUrl []string `yaml:"githubrepositoryurl"`
+	GitHubRepositoryUrl []string `yaml:"githubRepositoryUrl"`
 	Name                string   `yaml:"name"`
+	AuthorizationType   string   `yaml:"authorizationType"`
 }
 
 // Used to store the data from the YAML file
 type ConnectionFileData struct {
 	ID                  string   `yaml:"id"`
-	GitHubRepositoryUrl []string `yaml:"githubrepositoryurl"`
+	GitHubRepositoryUrl []string `yaml:"githubRepositoryUrl"`
 	Name                string   `yaml:"name"`
 }
 
@@ -521,6 +522,7 @@ func outputConnectionFile() (string, error) {
 			ID:                  c.ID,
 			GitHubRepositoryUrl: urls,
 			Name:                c.Name,
+			AuthorizationType:   c.AuthorizationType,
 		})
 	}
 


### PR DESCRIPTION
This PR implements the functionality to copy (i.e. "graft") an ADO connection ID and its connected GitHub repos from one ADO connection to another. 

It expects a .yml file, generated from another `artado` subcommand called `output`. This creates a snapshot of a ADO<->GitHub connection state, and `graft` reads in this file to copy repo URLs between connection IDs. 